### PR TITLE
Azure Kinect Body Tracking SDK 0.9.4 release sample update

### DIFF
--- a/body-tracking-samples/README.md
+++ b/body-tracking-samples/README.md
@@ -1,0 +1,5 @@
+# Azure Kinect Body Tracking Samples
+
+## Introduction
+
+This folder contains all the official samples that demonstrate how to use the Azure Kinect Body Tracking SDK.

--- a/body-tracking-samples/jump_analysis_sample/DigitalSignalProcessing.h
+++ b/body-tracking-samples/jump_analysis_sample/DigitalSignalProcessing.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <vector>
 
 #include <k4abttypes.h>
@@ -26,4 +27,41 @@ namespace DSP
     IndexValueTuple FindMinimum(const std::vector<float>& signal, size_t minIdx, size_t maxIdx);
 
     float Angle(k4a_float3_t A, k4a_float3_t B, k4a_float3_t C);
+
+    class RollingWindow
+    {
+    public:
+        RollingWindow(int windowSize)
+        {
+            m_window.resize(windowSize, 0);
+            m_circularIndex = windowSize - 1;
+        }
+        void Update(const std::chrono::microseconds& timestamp, float v)
+        {
+            m_circularIndex = (m_circularIndex + 1) % m_window.size();
+
+            m_movingAverageDelta = (v - m_window[m_circularIndex]) / m_window.size();
+            m_movingAverage += m_movingAverageDelta;
+            m_window[m_circularIndex] = v;
+
+            if (m_circularIndex == m_window.size() - 1)
+            {
+                m_filled = true;
+            }
+            m_timestampDelta = timestamp - m_timestamp;
+            m_timestamp = timestamp;
+        }
+        bool IsValid() const { return m_filled; }
+        float GetMovingAverage() const { return m_movingAverage; }
+        float GetMovingAverageVelocity() const { return m_movingAverageDelta / m_timestampDelta.count(); }
+
+    private:
+        std::vector<float> m_window;
+        float m_movingAverage = 0;
+        float m_movingAverageDelta = 0;
+        size_t m_circularIndex = 0;
+        bool m_filled = false;
+        std::chrono::microseconds m_timestamp;
+        std::chrono::microseconds m_timestampDelta;
+    };
 };

--- a/body-tracking-samples/jump_analysis_sample/JumpEvaluator.cpp
+++ b/body-tracking-samples/jump_analysis_sample/JumpEvaluator.cpp
@@ -386,12 +386,12 @@ void JumpEvaluator::CreateRenderWindow(
     int windowIndex,
     k4a_float3_t standingPosition)
 {
-    window.Create(windowName.c_str(), K4A_DEPTH_MODE_WFOV_2X2BINNED);
+    window.Create(windowName.c_str(), K4A_DEPTH_MODE_WFOV_2X2BINNED, m_defaultWindowWidth, m_defaultWindowHeight);
     window.SetCloseCallback(ReviewWindowCloseCallback, &m_reviewWindowIsRunning);
     window.AddBody(body, g_bodyColors[0]);
     window.SetFloorRendering(true, standingPosition.v[0] / 1000.f, standingPosition.v[1] / 1000.f, standingPosition.v[2] / 1000.f);
 
-    int xPos = windowIndex * 640;
+    int xPos = windowIndex * m_defaultWindowWidth;
     int yPos = 100;
     window.SetWindowPosition(xPos, yPos);
 }

--- a/body-tracking-samples/jump_analysis_sample/JumpEvaluator.h
+++ b/body-tracking-samples/jump_analysis_sample/JumpEvaluator.h
@@ -73,6 +73,10 @@ private:
     HandRaisedDetector m_handRaisedDetector;
     bool m_previousHandsAreRaised = false;
 
+    // Default jump analysis window size
+    const int m_defaultWindowWidth = 640;
+    const int m_defaultWindowHeight = 576;
+
     Window3dWrapper m_window3dSquatPose;
     Window3dWrapper m_window3dJumpPeakPose;
     Window3dWrapper m_window3dReplay;

--- a/body-tracking-samples/jump_analysis_sample/README.md
+++ b/body-tracking-samples/jump_analysis_sample/README.md
@@ -1,0 +1,23 @@
+# Azure Kinect Body Tracking JumpAnalysis Sample
+
+## Introduction
+
+The Azure Kinect Body Tracking JumpAnalysis sample leverages the body tracking SDK to perform quantitative analysis to
+a jump section performed by a single user. After each jump section, it will output the jump height, counter movement,
+push-off velocity and the squat knee angle. It demonstrates how users can write some simple code to build analysis in 3d.
+
+## Usage Info
+
+```
+jump_analysis_sample.exe
+```
+
+## Instruction
+
+1. Make sure you place the camera parallel to the floor and there is only one person in the scene.
+2. Raise both of your hands above your head or hit 'space' key to start the jump session.
+3. Perform a jump. Try to land at the same location as the starting point.
+4. Raise both of your hands above your head or hit 'space' key again to finish the session.
+5. Three 3d windows will pop up to show the moment of your deepest squat, jump peak and a replay of your full jump session.
+   Your jump analysis results will also be printed out on the command prompt.
+6. Close any of the 3d windows to go back to the idle stage.

--- a/body-tracking-samples/offline_processor/README.md
+++ b/body-tracking-samples/offline_processor/README.md
@@ -1,0 +1,17 @@
+# Azure Kinect Body Tracking OfflineProcessor Sample
+
+## Introduction
+
+The Azure Kinect Body Tracking OfflineProcessor sample demonstrates how to playback a recording Azure Kinect MKV file,
+run through the body tracking SDK and store the body tracking results in a json file.
+
+Notice: the current implementation is not the most efficient way to process a recording file offline. It simply
+synchronously pushes and pops the capture to/from the tracker queue. To achieve the best performance, you would need to
+create separate reader thread and process thread. And keep pushing new frames to the tracker without waiting for the
+k4abt_pop_result to return successfully.
+
+## Usage Info
+
+```
+offline_processor.exe <input_mkv_file> <output_json_file>
+```

--- a/body-tracking-samples/offline_processor/main.cpp
+++ b/body-tracking-samples/offline_processor/main.cpp
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <iomanip>
+
+#include <k4a/k4a.h>
+#include <k4arecord/playback.h>
+#include <k4abt.h>
+#include <nlohmann/json.hpp>
+
+#include <BodyTrackingHelpers.h>
+#include <Utilities.h>
+
+using namespace std;
+using namespace nlohmann;
+
+bool predict_joints(json &frames_json, int frame_count, k4abt_tracker_t tracker, k4a_capture_t capture_handle)
+{
+    k4a_wait_result_t queue_capture_result = k4abt_tracker_enqueue_capture(tracker, capture_handle, K4A_WAIT_INFINITE);
+    if (queue_capture_result != K4A_WAIT_RESULT_SUCCEEDED)
+    {
+        cerr << "Error! Adding capture to tracker process queue failed!" << endl;
+        return false;
+    }
+
+    k4abt_frame_t body_frame = nullptr;
+    k4a_wait_result_t pop_frame_result = k4abt_tracker_pop_result(tracker, &body_frame, K4A_WAIT_INFINITE);
+    if (pop_frame_result != K4A_WAIT_RESULT_SUCCEEDED)
+    {
+        cerr << "Error! Popping body tracking result failed!" << endl;
+        return false;
+    }
+
+    size_t num_bodies = k4abt_frame_get_num_bodies(body_frame);
+    uint64_t timestamp = k4abt_frame_get_device_timestamp_usec(body_frame);
+
+    json frame_result_json;
+    frame_result_json["timestamp_usec"] = timestamp;
+    frame_result_json["frame_id"] = frame_count;
+    frame_result_json["num_bodies"] = num_bodies;
+    frame_result_json["bodies"] = json::array();
+    for (size_t i = 0; i < num_bodies; i++)
+    {
+        k4abt_skeleton_t skeleton;
+        VERIFY(k4abt_frame_get_body_skeleton(body_frame, i, &skeleton), "Get body from body frame failed!");
+        json body_result_json;
+        int body_id = k4abt_frame_get_body_id(body_frame, i);
+        body_result_json["body_id"] = body_id;
+
+        for (int j = 0; j < (int)K4ABT_JOINT_COUNT; j++)
+        {
+            body_result_json["joint_positions"].push_back( {    skeleton.joints[j].position.xyz.x,
+                                                                skeleton.joints[j].position.xyz.y,
+                                                                skeleton.joints[j].position.xyz.z });
+
+            body_result_json["joint_orientations"].push_back({  skeleton.joints[j].orientation.wxyz.w,
+                                                                skeleton.joints[j].orientation.wxyz.x,
+                                                                skeleton.joints[j].orientation.wxyz.y,
+                                                                skeleton.joints[j].orientation.wxyz.z });
+        }
+        frame_result_json["bodies"].push_back(body_result_json);
+    }
+    frames_json.push_back(frame_result_json);
+    k4abt_frame_release(body_frame);
+
+    return true;
+}
+
+bool check_depth_image_exists(k4a_capture_t capture)
+{
+    k4a_image_t depth = k4a_capture_get_depth_image(capture);
+    if (depth != nullptr)
+    {
+        k4a_image_release(depth);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool process_mkv_offline(const char* input_path, const char* output_path)
+{
+    k4a_playback_t playback_handle = nullptr;
+    k4a_result_t result = k4a_playback_open(input_path, &playback_handle);
+    if (result != K4A_RESULT_SUCCEEDED)
+    {
+        cerr << "Cannot open recording at " << input_path << endl;
+        return false;
+    }
+
+    k4a_calibration_t calibration;
+    result = k4a_playback_get_calibration(playback_handle, &calibration);
+    if (result != K4A_RESULT_SUCCEEDED)
+    {
+        cerr << "Failed to get calibration" << endl;
+        return false;
+    }
+
+    k4abt_tracker_t tracker = NULL;
+    k4abt_tracker_configuration_t tracker_config = K4ABT_TRACKER_CONFIG_DEFAULT;
+    if (K4A_RESULT_SUCCEEDED != k4abt_tracker_create(&calibration, tracker_config, &tracker))
+    {
+        cerr << "Body tracker initialization failed!" << endl;
+        return false;
+    }
+
+    json json_output;
+    json_output["k4abt_sdk_version"] = K4ABT_VERSION_STR;
+    json_output["source_file"] = input_path;
+
+    // Store all joint names to the json
+    json_output["joint_names"] = json::array();
+    for (int i = 0; i < (int)K4ABT_JOINT_COUNT; i++)
+    {
+        json_output["joint_names"].push_back(g_jointNames.find((k4abt_joint_id_t)i)->second);
+    }
+
+    // Store all bone linkings to the json
+    json_output["bone_list"] = json::array();
+    for (int i = 0; i < (int)g_boneList.size(); i++)
+    {
+        json_output["bone_list"].push_back(
+            basic_json(pair<string, string>(
+                g_jointNames.find(g_boneList[i].first)->second,
+                g_jointNames.find(g_boneList[i].second)->second)));
+    }
+
+    cout << "Tracking " << input_path << endl;
+
+    int frame_count = 0;
+    json frames_json = json::array();
+    bool success = true;
+    while (true)
+    {
+        k4a_capture_t capture_handle = nullptr;
+        k4a_stream_result_t stream_result = k4a_playback_get_next_capture(playback_handle, &capture_handle);
+        if (stream_result == K4A_STREAM_RESULT_EOF)
+        {
+            break;
+        }
+
+        cout << "frame " << frame_count << '\r';
+        if (stream_result == K4A_STREAM_RESULT_SUCCEEDED)
+        {
+            // Only try to predict joints when capture contains depth image
+            if (check_depth_image_exists(capture_handle))
+            {
+                success = predict_joints(frames_json, frame_count, tracker, capture_handle);
+                k4a_capture_release(capture_handle);
+                if (!success)
+                {
+                    cerr << "Predict joints failed for clip at frame " << frame_count << endl;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            success = false;
+            cerr << "Stream error for clip at frame " << frame_count << endl;
+            break;
+        }
+
+        frame_count++;
+    }
+
+    if (success)
+    {
+        json_output["frames"] = frames_json;
+        cout << endl << "DONE " << endl;
+
+        cout << "Total read " << frame_count << " frames" << endl;
+        std::ofstream output_file(output_path);
+        output_file << std::setw(4) << json_output << std::endl;
+        cout << "Results saved in " << output_path;
+    }
+
+    k4a_playback_close(playback_handle);
+
+    return success;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3)
+    {
+        cout << "Usage: k4abt_offline_processor.exe <input_mkv_file> <output_json_file>" << endl;
+        return -1;
+    }
+
+    return process_mkv_offline(argv[1], argv[2]) ? 0 : -1;
+}

--- a/body-tracking-samples/offline_processor/main.cpp
+++ b/body-tracking-samples/offline_processor/main.cpp
@@ -124,10 +124,8 @@ bool process_mkv_offline(const char* input_path, const char* output_path)
     json_output["bone_list"] = json::array();
     for (int i = 0; i < (int)g_boneList.size(); i++)
     {
-        json_output["bone_list"].push_back(
-            basic_json(pair<string, string>(
-                g_jointNames.find(g_boneList[i].first)->second,
-                g_jointNames.find(g_boneList[i].second)->second)));
+        json_output["bone_list"].push_back({ g_jointNames.find(g_boneList[i].first)->second,
+                                             g_jointNames.find(g_boneList[i].second)->second });
     }
 
     cout << "Tracking " << input_path << endl;

--- a/body-tracking-samples/offline_processor/offline_processor.sln
+++ b/body-tracking-samples/offline_processor/offline_processor.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2048
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "offline_processor", "offline_processor.vcxproj", "{A7D2F1BE-0030-4436-B391-FEDE1E756B02}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7D2F1BE-0030-4436-B391-FEDE1E756B02}.Debug|x64.ActiveCfg = Debug|x64
+		{A7D2F1BE-0030-4436-B391-FEDE1E756B02}.Debug|x64.Build.0 = Debug|x64
+		{A7D2F1BE-0030-4436-B391-FEDE1E756B02}.Release|x64.ActiveCfg = Release|x64
+		{A7D2F1BE-0030-4436-B391-FEDE1E756B02}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9CED7691-CE0F-4724-B1DE-8F4E7DF58EF5}
+	EndGlobalSection
+EndGlobal

--- a/body-tracking-samples/offline_processor/offline_processor.vcxproj
+++ b/body-tracking-samples/offline_processor/offline_processor.vcxproj
@@ -12,15 +12,15 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{D50DDE2C-13FB-4121-BB86-942CC8E81019}</ProjectGuid>
-    <RootNamespace>jump_analysis_sample</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectGuid>{A7D2F1BE-0030-4436-B391-FEDE1E756B02}</ProjectGuid>
+    <RootNamespace>offline_processor</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -43,18 +43,18 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
-    <IncludePath>..\sample_helper_includes;..\sample_helper_libs\window_controller_3d;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)\build\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\build\temp\$(Configuration)\$(MSBuildProjectName)\</IntDir>
+    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
+    <IncludePath>..\sample_helper_includes;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
-    <IncludePath>..\sample_helper_includes;..\sample_helper_libs\window_controller_3d;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)\build\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\build\temp\$(Configuration)\$(MSBuildProjectName)\</IntDir>
+    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
+    <IncludePath>..\sample_helper_includes;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -62,7 +62,6 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
@@ -76,7 +75,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -85,20 +83,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="DigitalSignalProcessing.cpp" />
-    <ClCompile Include="HandRaisedDetector.cpp" />
-    <ClCompile Include="JumpEvaluator.cpp" />
     <ClCompile Include="main.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\sample_helper_libs\window_controller_3d\window_controller_3d.vcxproj">
-      <Project>{9e78b4cc-b641-42a1-8375-75a2cc8b3124}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="DSP.h" />
-    <ClInclude Include="HandRaisedDetector.h" />
-    <ClInclude Include="JumpEvaluator.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="dnn_model_2_0.onnx" />
@@ -108,7 +93,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
-    <Import Project="$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets" Condition="Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" />
+    <Import Project="packages\nlohmann.json.3.7.0\build\native\nlohmann.json.targets" Condition="Exists('packages\nlohmann.json.3.7.0\build\native\nlohmann.json.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -116,6 +101,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets'))" />
+    <Error Condition="!Exists('packages\nlohmann.json.3.7.0\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\nlohmann.json.3.7.0\build\native\nlohmann.json.targets'))" />
   </Target>
 </Project>

--- a/body-tracking-samples/offline_processor/offline_processor.vcxproj
+++ b/body-tracking-samples/offline_processor/offline_processor.vcxproj
@@ -20,7 +20,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/body-tracking-samples/offline_processor/offline_processor.vcxproj.filters
+++ b/body-tracking-samples/offline_processor/offline_processor.vcxproj.filters
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="dnn_model_2_0.onnx" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\content\**\*.*" />
+  </ItemGroup>
+</Project>

--- a/body-tracking-samples/offline_processor/packages.config
+++ b/body-tracking-samples/offline_processor/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="glfw" version="3.3.0" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.4" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.Sensor" version="1.2.0" targetFramework="native" />
+  <package id="nlohmann.json" version="3.7.0" targetFramework="native" />
 </packages>

--- a/body-tracking-samples/sample_helper_includes/BodyTrackingHelpers.h
+++ b/body-tracking-samples/sample_helper_includes/BodyTrackingHelpers.h
@@ -4,10 +4,11 @@
 #pragma once
 
 #include <array>
+#include <unordered_map>
 #include <k4abttypes.h>
 
 // Define the bone list based on the documentation
-const std::array<std::pair<k4abt_joint_id_t, k4abt_joint_id_t>, 25> g_boneList =
+const std::array<std::pair<k4abt_joint_id_t, k4abt_joint_id_t>, 31> g_boneList =
 {
     std::make_pair(K4ABT_JOINT_SPINE_CHEST, K4ABT_JOINT_SPINE_NAVAL),
     std::make_pair(K4ABT_JOINT_SPINE_NAVAL, K4ABT_JOINT_PELVIS),
@@ -19,6 +20,9 @@ const std::array<std::pair<k4abt_joint_id_t, k4abt_joint_id_t>, 25> g_boneList =
     std::make_pair(K4ABT_JOINT_CLAVICLE_LEFT, K4ABT_JOINT_SHOULDER_LEFT),
     std::make_pair(K4ABT_JOINT_SHOULDER_LEFT, K4ABT_JOINT_ELBOW_LEFT),
     std::make_pair(K4ABT_JOINT_ELBOW_LEFT, K4ABT_JOINT_WRIST_LEFT),
+    std::make_pair(K4ABT_JOINT_WRIST_LEFT, K4ABT_JOINT_HAND_LEFT),
+    std::make_pair(K4ABT_JOINT_HAND_LEFT, K4ABT_JOINT_HANDTIP_LEFT),
+    std::make_pair(K4ABT_JOINT_WRIST_LEFT, K4ABT_JOINT_THUMB_LEFT),
     std::make_pair(K4ABT_JOINT_PELVIS, K4ABT_JOINT_HIP_LEFT),
     std::make_pair(K4ABT_JOINT_HIP_LEFT, K4ABT_JOINT_KNEE_LEFT),
     std::make_pair(K4ABT_JOINT_KNEE_LEFT, K4ABT_JOINT_ANKLE_LEFT),
@@ -30,12 +34,46 @@ const std::array<std::pair<k4abt_joint_id_t, k4abt_joint_id_t>, 25> g_boneList =
     std::make_pair(K4ABT_JOINT_CLAVICLE_RIGHT, K4ABT_JOINT_SHOULDER_RIGHT),
     std::make_pair(K4ABT_JOINT_SHOULDER_RIGHT, K4ABT_JOINT_ELBOW_RIGHT),
     std::make_pair(K4ABT_JOINT_ELBOW_RIGHT, K4ABT_JOINT_WRIST_RIGHT),
+    std::make_pair(K4ABT_JOINT_WRIST_RIGHT, K4ABT_JOINT_HAND_RIGHT),
+    std::make_pair(K4ABT_JOINT_HAND_RIGHT, K4ABT_JOINT_HANDTIP_RIGHT),
+    std::make_pair(K4ABT_JOINT_WRIST_RIGHT, K4ABT_JOINT_THUMB_RIGHT),
     std::make_pair(K4ABT_JOINT_PELVIS, K4ABT_JOINT_HIP_RIGHT),
     std::make_pair(K4ABT_JOINT_HIP_RIGHT, K4ABT_JOINT_KNEE_RIGHT),
     std::make_pair(K4ABT_JOINT_KNEE_RIGHT, K4ABT_JOINT_ANKLE_RIGHT),
     std::make_pair(K4ABT_JOINT_ANKLE_RIGHT, K4ABT_JOINT_FOOT_RIGHT),
     std::make_pair(K4ABT_JOINT_NOSE, K4ABT_JOINT_EYE_RIGHT),
     std::make_pair(K4ABT_JOINT_EYE_RIGHT, K4ABT_JOINT_EAR_RIGHT)
+};
+
+// Define the joint string names
+const std::unordered_map<k4abt_joint_id_t, std::string> g_jointNames =
+{
+    std::make_pair(K4ABT_JOINT_PELVIS,        "PELVIS"),
+    std::make_pair(K4ABT_JOINT_SPINE_NAVAL,   "SPINE_NAVAL"),
+    std::make_pair(K4ABT_JOINT_SPINE_CHEST,   "SPINE_CHEST"),
+    std::make_pair(K4ABT_JOINT_NECK,          "NECK"),
+    std::make_pair(K4ABT_JOINT_CLAVICLE_LEFT, "CLAVICLE_LEFT"),
+    std::make_pair(K4ABT_JOINT_SHOULDER_LEFT, "SHOULDER_LEFT"),
+    std::make_pair(K4ABT_JOINT_ELBOW_LEFT,    "ELBOW_LEFT"),
+    std::make_pair(K4ABT_JOINT_WRIST_LEFT,    "WRIST_LEFT"),
+    std::make_pair(K4ABT_JOINT_CLAVICLE_RIGHT,"CLAVICLE_RIGHT"),
+    std::make_pair(K4ABT_JOINT_SHOULDER_RIGHT,"SHOULDER_RIGHT"),
+    std::make_pair(K4ABT_JOINT_ELBOW_RIGHT,   "ELBOW_RIGHT"),
+    std::make_pair(K4ABT_JOINT_WRIST_RIGHT,   "WRIST_RIGHT"),
+    std::make_pair(K4ABT_JOINT_HIP_LEFT,      "HIP_LEFT"),
+    std::make_pair(K4ABT_JOINT_KNEE_LEFT,     "KNEE_LEFT"),
+    std::make_pair(K4ABT_JOINT_ANKLE_LEFT,    "ANKLE_LEFT"),
+    std::make_pair(K4ABT_JOINT_FOOT_LEFT,     "FOOT_LEFT"),
+    std::make_pair(K4ABT_JOINT_HIP_RIGHT,     "HIP_RIGHT"),
+    std::make_pair(K4ABT_JOINT_KNEE_RIGHT,    "KNEE_RIGHT"),
+    std::make_pair(K4ABT_JOINT_ANKLE_RIGHT,   "ANKLE_RIGHT"),
+    std::make_pair(K4ABT_JOINT_FOOT_RIGHT,    "FOOT_RIGHT"),
+    std::make_pair(K4ABT_JOINT_HEAD,          "HEAD"),
+    std::make_pair(K4ABT_JOINT_NOSE,          "NOSE"),
+    std::make_pair(K4ABT_JOINT_EYE_LEFT,      "EYE_LEFT"),
+    std::make_pair(K4ABT_JOINT_EAR_LEFT,      "EAR_LEFT"),
+    std::make_pair(K4ABT_JOINT_EYE_RIGHT,     "EYE_RIGHT"),
+    std::make_pair(K4ABT_JOINT_EAR_RIGHT,     "EAR_RIGHT")
 };
 
 struct Color

--- a/body-tracking-samples/sample_helper_includes/README.md
+++ b/body-tracking-samples/sample_helper_includes/README.md
@@ -1,0 +1,5 @@
+# Azure Kinect Body Tracking Helper Includes
+
+## Introduction
+
+The Azure Kinect Body Tracking Helper Includes are some common helper header files that are shared between sample projects.

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/README.md
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/README.md
@@ -1,0 +1,6 @@
+# Azure Kinect Body Tracking WindowController3d Library
+
+## Introduction
+
+The Azure Kinect Body Tracking WindowController3d Library is a visualization helper library that renders the body
+tracking results into a 3d window.

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/Window3dWrapper.h
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/Window3dWrapper.h
@@ -18,7 +18,9 @@ public:
     // Create Window3d wrapper without point cloud shading
     void Create(
         const char* name,
-        k4a_depth_mode_t depthMode);
+        k4a_depth_mode_t depthMode,
+        int windowWidth = -1,
+        int windowHeight = -1);
 
     // Create Window3d wrapper with point cloud shading
     void Create(

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/WindowController3d.cpp
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/WindowController3d.cpp
@@ -73,8 +73,21 @@ void WindowController3d::Create(const char* name, bool showWindow, int width, in
     {
         glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
     }
-    m_windowWidth = width;
-    m_windowHeight = height;
+
+    const GLFWvidmode* displayInfo = glfwGetVideoMode(glfwGetPrimaryMonitor());
+    if (width <= 0 || height <= 0)
+    {
+        m_windowWidth = static_cast<int>(displayInfo->width * m_defaultWindowWidthRatio);
+        m_windowHeight = static_cast<int>(displayInfo->height * m_defaultWindowHeightRatio);
+    }
+    else
+    {
+        m_windowWidth = width;
+        m_windowHeight = height;
+    }
+
+    m_windowStartPositionX = (displayInfo->width - m_windowWidth) / 2;
+    m_windowStartPositionY = (displayInfo->height - m_windowHeight) / 2;
 
     // Get monitor for full screen
     GLFWmonitor* monitor = nullptr;
@@ -105,6 +118,8 @@ void WindowController3d::Create(const char* name, bool showWindow, int width, in
         glfwTerminate();
         exit(EXIT_FAILURE);
     }
+
+    glfwSetWindowPos(m_window, m_windowStartPositionX, m_windowStartPositionY);
 
     // In to use the member function as callback, set the current class as the Window User Pointer
     glfwSetWindowUserPointer(m_window, this);

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/WindowController3d.h
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/WindowController3d.h
@@ -44,8 +44,8 @@ namespace Visualization
         void Create(
             const char *name,
             bool showWindow = true,
-            int width = 640,
-            int height = 576,
+            int width = -1,
+            int height = -1,
             bool fullscreen = false);
 
         void Delete();
@@ -136,8 +136,12 @@ namespace Visualization
         float m_deltaTime = 0.f;
 
         // Window information
-        int m_windowWidth = 640;
-        int m_windowHeight = 576;
+        int m_windowWidth;
+        int m_windowHeight;
+        int m_windowStartPositionX;  // the upper-left corner of the window position
+        int m_windowStartPositionY;  // the upper-left corner of the window position
+        float m_defaultWindowWidthRatio = 0.6f;  // Default window width ratio relative to the full display screen
+        float m_defaultWindowHeightRatio = 0.6f;  // Default window height ratio relative to the full display screen
 
         // OpenGL resources
         GLFWwindow* m_window = nullptr;

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/packages.config
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="glfw" version="3.3.0" targetFramework="native" />
-  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.3" targetFramework="native" />
+  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.4" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.Sensor" version="1.2.0" targetFramework="native" />
 </packages>

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/window_controller_3d.vcxproj
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/window_controller_3d.vcxproj
@@ -116,7 +116,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
     <Import Project="$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets" Condition="Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -124,7 +124,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets'))" />
   </Target>
 </Project>

--- a/body-tracking-samples/simple_3d_viewer/README.md
+++ b/body-tracking-samples/simple_3d_viewer/README.md
@@ -1,0 +1,35 @@
+# Azure Kinect Body Tracking Simple3dViewer Sample
+
+## Introduction
+
+The Azure Kinect Body Tracking Simple3dViewer sample creates a 3d window that visualizes all the information provided
+by the body tracking SDK.
+
+## Usage Info
+
+USAGE: simple_3d_viewer.exe SensorMode[NFOV_UNBINNED, WFOV_BINNED](optional) RuntimeMode[CPU](optional)
+* SensorMode:
+  * NFOV_UNBINNED (default) - Narraw Field of View Unbinned Mode [Resolution: 640x576; FOI: 75 degree x 65 degree]
+  * WFOV_BINNED             - Wide Field of View Binned Mode [Resolution: 512x512; FOI: 120 degree x 120 degree]
+* RuntimeMode:
+  * CPU - Use the CPU only mode. It runs on machines without a GPU but it will be much slower
+
+```
+e.g.   simple_3d_viewer.exe WFOV_BINNED CPU
+                 simple_3d_viewer.exe CPU
+                 simple_3d_viewer.exe WFOV_BINNED
+```
+
+## Instruction
+
+### Basic Navigation:
+* Rotate: Rotate the camera by moving the mouse while holding mouse left button
+* Pan: Translate the scene by holding Ctrl key and drag the scene with mouse left button
+* Zoom in/out: Move closer/farther away from the scene center by scrolling the mouse scroll wheel
+* Select Center: Center the scene based on a detected joint by right clicking the joint with mouse
+
+### Key Shortcuts
+* ESC: quit
+* h: help
+* b: body visualization mode
+* k: 3d window layout

--- a/body-tracking-samples/simple_3d_viewer/packages.config
+++ b/body-tracking-samples/simple_3d_viewer/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="glfw" version="3.3.0" targetFramework="native" />
-  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.3" targetFramework="native" />
+  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.4" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.Sensor" version="1.2.0" targetFramework="native" />
 </packages>

--- a/body-tracking-samples/simple_3d_viewer/simple_3d_viewer.vcxproj
+++ b/body-tracking-samples/simple_3d_viewer/simple_3d_viewer.vcxproj
@@ -99,7 +99,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
     <Import Project="$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets" Condition="Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -107,7 +107,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\glfw.3.3.0\build\native\glfw.targets'))" />
   </Target>
 </Project>

--- a/body-tracking-samples/simple_cpp_sample/README.md
+++ b/body-tracking-samples/simple_cpp_sample/README.md
@@ -1,0 +1,11 @@
+# Azure Kinect Body Tracking SimpleCpp Sample
+
+## Introduction
+
+The Azure Kinect Body Tracking SimpleCpp sample is the simplest example that demonstrates how to use the body tracking SDK cpp wrapper.
+
+## Usage Info
+
+```
+simple_cpp_sample.exe
+```

--- a/body-tracking-samples/simple_cpp_sample/main.cpp
+++ b/body-tracking-samples/simple_cpp_sample/main.cpp
@@ -14,8 +14,9 @@ void print_body_information(k4abt_body_t body)
     {
         k4a_float3_t position = body.skeleton.joints[i].position;
         k4a_quaternion_t orientation = body.skeleton.joints[i].orientation;
-        printf("Joint[%d]: Position[mm] ( %f, %f, %f ); Orientation ( %f, %f, %f, %f) \n",
-            i, position.v[0], position.v[1], position.v[2], orientation.v[0], orientation.v[1], orientation.v[2], orientation.v[3]);
+        k4abt_joint_confidence_level_t confidence_level = body.skeleton.joints[i].confidence_level;
+        printf("Joint[%d]: Position[mm] ( %f, %f, %f ); Orientation ( %f, %f, %f, %f); Confidence Level (%d)  \n",
+            i, position.v[0], position.v[1], position.v[2], orientation.v[0], orientation.v[1], orientation.v[2], orientation.v[3], confidence_level);
     }
 }
 

--- a/body-tracking-samples/simple_cpp_sample/packages.config
+++ b/body-tracking-samples/simple_cpp_sample/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.3" targetFramework="native" />
+  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.4" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.Sensor" version="1.2.0" targetFramework="native" />
 </packages>

--- a/body-tracking-samples/simple_cpp_sample/simple_cpp_sample.vcxproj
+++ b/body-tracking-samples/simple_cpp_sample/simple_cpp_sample.vcxproj
@@ -92,13 +92,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
   </Target>
 </Project>

--- a/body-tracking-samples/simple_sample/README.md
+++ b/body-tracking-samples/simple_sample/README.md
@@ -1,0 +1,11 @@
+# Azure Kinect Body Tracking Simple Sample
+
+## Introduction
+
+The Azure Kinect Body Tracking Simple sample is the simplest sample that demonstrates how to use the body tracking SDK C API.
+
+## Usage Info
+
+```
+simple_sample.exe
+```

--- a/body-tracking-samples/simple_sample/main.c
+++ b/body-tracking-samples/simple_sample/main.c
@@ -23,8 +23,9 @@ void print_body_information(k4abt_body_t body)
     {
         k4a_float3_t position = body.skeleton.joints[i].position;
         k4a_quaternion_t orientation = body.skeleton.joints[i].orientation;
-        printf("Joint[%d]: Position[mm] ( %f, %f, %f ); Orientation ( %f, %f, %f, %f) \n",
-            i, position.v[0], position.v[1], position.v[2], orientation.v[0], orientation.v[1], orientation.v[2], orientation.v[3]);
+        k4abt_joint_confidence_level_t confidence_level = body.skeleton.joints[i].confidence_level;
+        printf("Joint[%d]: Position[mm] ( %f, %f, %f ); Orientation ( %f, %f, %f, %f); Confidence Level (%d) \n",
+            i, position.v[0], position.v[1], position.v[2], orientation.v[0], orientation.v[1], orientation.v[2], orientation.v[3], confidence_level);
     }
 }
 

--- a/body-tracking-samples/simple_sample/packages.config
+++ b/body-tracking-samples/simple_sample/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.3" targetFramework="native" />
+  <package id="Microsoft.Azure.Kinect.BodyTracking" version="0.9.4" targetFramework="native" />
   <package id="Microsoft.Azure.Kinect.Sensor" version="1.2.0" targetFramework="native" />
 </packages>

--- a/body-tracking-samples/simple_sample/simple_sample.vcxproj
+++ b/body-tracking-samples/simple_sample/simple_sample.vcxproj
@@ -92,13 +92,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.Sensor.1.2.0\build\native\Microsoft.Azure.Kinect.Sensor.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.3\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Azure.Kinect.BodyTracking.0.9.4\build\native\Microsoft.Azure.Kinect.BodyTracking.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
1. Link all sample projects to the latest Azure Kinect Body Tracking SDK 0.9.4 release. 
2. Support additional hand joints and joint confidence level visualization in the simple 3d viewer sample. 
3. Add the ability to dynamically decide the window size for the simple 3d viewer. 
4. Add an additional offline processor sample to demonstrates how the SDK can be used for some sensor recording data. 
5. Add README.md for all samples.