### PR TITLE
Fix the error "error: `gl_FragColor' undeclared" which occurs on the Open Source OpenGL drivers

### DIFF
--- a/body-tracking-samples/csharp_3d_viewer/Shaders.cs
+++ b/body-tracking-samples/csharp_3d_viewer/Shaders.cs
@@ -30,6 +30,7 @@ namespace Csharp_3d_viewer
 
         private const string FragmentShaderText = @"
             #version 430
+            out vec4 fragColor;
             varying vec4 fragmentColor;
             varying vec3 fragmentPosition;
             varying vec3 fragmentNormal;
@@ -45,7 +46,7 @@ namespace Csharp_3d_viewer
                 lightDir = normalize(lightDir);
                 float diffuse = abs(dot(norm, lightDir)) / dist2;
 
-                gl_FragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
+                fragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
             }
         ";
 

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/ColorObjectShaders.h
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/ColorObjectShaders.h
@@ -35,6 +35,7 @@ static const char* const glslColorObjectVertexShader = GLSL_STRING(
 // ************** Color Object Fragment Shader **************
 static const char* const glslColorObjectFragmentShader = GLSL_STRING(
 
+    out vec4 fragColor;
     varying vec4 fragmentColor;
     varying vec3 fragmentPosition;
     varying vec3 fragmentNormal;
@@ -48,7 +49,7 @@ static const char* const glslColorObjectFragmentShader = GLSL_STRING(
         vec3 lightDir = normalize(lightPosition - fragmentPosition);
         float diffuse = abs(dot(norm, lightDir));
 
-        gl_FragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
+        fragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
     }
 
 );  // GLSL_STRING

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/MonoObjectShaders.h
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/MonoObjectShaders.h
@@ -35,6 +35,7 @@ static const char* const glslMonoObjectVertexShader = GLSL_STRING(
 // ************** Mono Object Fragment Shader **************
 static const char* const glslMonoObjectFragmentShader = GLSL_STRING(
 
+    out vec4 fragColor;
     varying vec4 fragmentColor;
     varying vec3 fragmentPosition;
     varying vec3 fragmentNormal;
@@ -48,7 +49,7 @@ static const char* const glslMonoObjectFragmentShader = GLSL_STRING(
         vec3 lightDir = normalize(lightPosition - fragmentPosition);
         float diffuse = abs(dot(norm, lightDir));
 
-        gl_FragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
+        fragColor = vec4(fragmentColor.rgb * diffuse, fragmentColor.a);
     }
 
 );  // GLSL_STRING

--- a/body-tracking-samples/sample_helper_libs/window_controller_3d/PointCloudShaders.h
+++ b/body-tracking-samples/sample_helper_libs/window_controller_3d/PointCloudShaders.h
@@ -96,11 +96,12 @@ static const char* const glslPointCloudVertexShader = GLSL_STRING(
 // ************** Point Cloud Fragment Shader **************
 static const char* const glslPointCloudFragmentShader = GLSL_STRING(
 
+    out vec4 fragColor;
     in vec4 fragmentColor;
 
     void main()
     {
-        gl_FragColor = fragmentColor;
+        fragColor = fragmentColor;
     }
 
 );  // GLSL_STRING


### PR DESCRIPTION
This replaces the deprecated fragment output variable with the recommended solution.