### PR TITLE
Fix miscalculated LUT scale factor

### DIFF
--- a/body-tracking-samples/csharp_3d_viewer/PointCloud.cs
+++ b/body-tracking-samples/csharp_3d_viewer/PointCloud.cs
@@ -26,8 +26,8 @@ namespace Csharp_3d_viewer
                     {
                         for (int u = 0; u < calibration.DepthCameraCalibration.ResolutionWidth; ++u, k += 3)
                         {
-                            // Divide by 1e6 to store points position per each 1 millimeter of z-distance.
-                            var point = new Vector3(pointCloudBuffer[k], pointCloudBuffer[k + 1], pointCloudBuffer[k + 2]) / 1000000;
+                            // Divide by 1e3 to store points position per each 1 millimeter of z-distance.
+                            var point = new Vector3(pointCloudBuffer[k], pointCloudBuffer[k + 1], pointCloudBuffer[k + 2]) / 1000;
                             pointCloudCache[v, u] = point;
                         }
                     }


### PR DESCRIPTION
The fake depth frame is set to 1000mm, but the example code was dividing the transformation result by 1,000,000, making the lookup table values off by a factor of 1000.

Maybe I'm missing something here, but when I put (pretty much) this exact method in my test code my point cloud values were all off by 1000x.