### PR TITLE
Fixed linking error when cmake was used, because k4arecord was not mentioned in the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 FIND_PACKAGE(k4a REQUIRED)
+FIND_PACKAGE(k4arecord REQUIRED)
 FIND_PACKAGE(k4abt REQUIRED)
 
 # These specific settings tell the loader to search the directory of the

--- a/body-tracking-samples/simple_3d_viewer/CMakeLists.txt
+++ b/body-tracking-samples/simple_3d_viewer/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(simple_3d_viewer PRIVATE ../sample_helper_includes)
 target_link_libraries(simple_3d_viewer PRIVATE 
     k4a
     k4abt
+    k4arecord
     window_controller_3d::window_controller_3d
     glfw::glfw
     )


### PR DESCRIPTION
Fixed linking error when cmake was used, because k4arecord was not mentioned in the CMakeLists.txt