### PR TITLE
Add printing for GLE

### DIFF
--- a/pipe-to-python-samples/main.cpp
+++ b/pipe-to-python-samples/main.cpp
@@ -211,7 +211,7 @@ DWORD WINAPI InstanceThread(LPVOID lpvParam)
         {
             if (GetLastError() == ERROR_BROKEN_PIPE)
             {
-                _tprintf(TEXT("InstanceThread: client disconnected.\n"), GetLastError());
+                _tprintf(TEXT("InstanceThread: client disconnected, GLE=%d.\n"), GetLastError());
             }
             else
             {


### PR DESCRIPTION
GetLastError() wasn't getting printed if the client was disconnected